### PR TITLE
The logout waits again for the onAuthStateChange listener to have completed

### DIFF
--- a/lib/yust.dart
+++ b/lib/yust.dart
@@ -18,7 +18,10 @@ class Yust {
     Firestore.instance.settings(persistenceEnabled: true);
 
     Yust.store.authState = AuthState.waiting;
-    FirebaseAuth.instance.onAuthStateChanged.listen((fireUser) async {
+    FirebaseAuth.instance.onAuthStateChanged.listen(
+
+        ///Calls [Yust.store.setState] on each event.
+        (fireUser) async {
       if (fireUser != null) {
         YustUser user = await Yust.service
             .getDoc<YustUser>(Yust.userSetup, fireUser.uid)

--- a/lib/yust_service.dart
+++ b/lib/yust_service.dart
@@ -82,6 +82,16 @@ class YustService {
   Future<void> signOut(BuildContext context) async {
     await fireAuth.signOut();
 
+    final completer = Completer<void>();
+    void complete() => completer.complete();
+
+    Yust.store.addListener(complete);
+
+    ///Awaits that the listener registered in the [Yust.initialize] method completed its work.
+    ///This also assumes that [fireAuth.signOut] was successfull, of which I do not know how to be certain.
+    await completer.future;
+    Yust.store.removeListener(complete);
+
     Navigator.of(context).pushNamedAndRemoveUntil(
       Navigator.defaultRouteName,
       (_) => false,


### PR DESCRIPTION
Reverts the changes introduced by commit 19de8c95acd1f92bd2a4879319cafeaa3ab91ccd.
This is necessary because when logging out the navigation to a new screen may only be triggered once the listener on onAuthStateChanged has completed its work.