### PR TITLE
Corrects the in filter

### DIFF
--- a/lib/yust_service.dart
+++ b/lib/yust_service.dart
@@ -487,7 +487,7 @@ class YustService {
 
             // Makes sure that no data is returned.
             if (operand2 == null) {
-              query = query.where(operand1, isNull: true);
+              query = query.where(operand1, isEqualTo: true, isNull: true);
             }
             break;
           case 'arrayContains':

--- a/lib/yust_service.dart
+++ b/lib/yust_service.dart
@@ -456,34 +456,38 @@ class YustService {
     if (filterList != null) {
       for (var filter in filterList) {
         assert(filter != null && filter.length == 3);
+        final operand1 = filter[0], operator = filter[1], operand2 = filter[2];
 
-        switch (filter[1]) {
+        switch (operator) {
           case '==':
-            query = query.where(filter[0], isEqualTo: filter[2]);
+            query = query.where(operand1, isEqualTo: operand2);
             break;
           case '<':
-            query = query.where(filter[0], isLessThan: filter[2]);
+            query = query.where(operand1, isLessThan: operand2);
             break;
           case '<=':
-            query = query.where(filter[0], isLessThanOrEqualTo: filter[2]);
+            query = query.where(operand1, isLessThanOrEqualTo: operand2);
             break;
           case '>':
-            query = query.where(filter[0], isGreaterThan: filter[2]);
+            query = query.where(operand1, isGreaterThan: operand2);
             break;
           case '>=':
-            query = query.where(filter[0], isGreaterThanOrEqualTo: filter[2]);
+            query = query.where(operand1, isGreaterThanOrEqualTo: operand2);
             break;
           case 'in':
-            query = query.where(filter[0], whereIn: filter[2]);
+            // If null is passed for the filter list, no filter is applied at all.
+            // If an empty list is passed, than no result are returned.
+            // I think that it should behave the same.
+            query = query.where(operand1, whereIn: operand2 ?? []);
             break;
           case 'arrayContains':
-            query = query.where(filter[0], arrayContains: filter[2]);
+            query = query.where(operand1, arrayContains: operand2);
             break;
           case 'isNull':
-            query = query.where(filter[0], isNull: filter[2]);
+            query = query.where(operand1, isNull: operand2);
             break;
           default:
-            throw 'The operator "${filter[1]}" is not supported.';
+            throw 'The operator "$operator" is not supported.';
         }
       }
     }

--- a/lib/yust_service.dart
+++ b/lib/yust_service.dart
@@ -456,7 +456,7 @@ class YustService {
     if (filterList != null) {
       for (var filter in filterList) {
         assert(filter != null && filter.length == 3);
-        final operand1 = filter[0], operator = filter[1], operand2 = filter[2];
+        var operand1 = filter[0], operator = filter[1], operand2 = filter[2];
 
         switch (operator) {
           case '==':
@@ -476,9 +476,19 @@ class YustService {
             break;
           case 'in':
             // If null is passed for the filter list, no filter is applied at all.
-            // If an empty list is passed, than no result are returned.
-            // I think that it should behave the same.
-            query = query.where(operand1, whereIn: operand2 ?? []);
+            // If an empty list is passed, an error is thrown.
+            // I think that it should behave the same and return no data.
+
+            if (operand2 != null && operand2 is List && operand2.isEmpty) {
+              operand2 = null;
+            }
+
+            query = query.where(operand1, whereIn: operand2);
+
+            // Makes sure that no data is returned.
+            if (operand2 == null) {
+              query = query.where(operand1, isNull: true);
+            }
             break;
           case 'arrayContains':
             query = query.where(operand1, arrayContains: operand2);


### PR DESCRIPTION
Previously the in filter did not actually filter the result if null was given for a list. If the list was empty an exception was thrown. Now both cases return no result.