### PR TITLE
Stateful YustDoc- and YustDocsBuilder

### DIFF
--- a/lib/widgets/yust_doc_builder.dart
+++ b/lib/widgets/yust_doc_builder.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 import '../models/yust_doc.dart';
@@ -10,13 +11,13 @@ class YustBuilderInsights {
   YustBuilderInsights({this.waiting});
 }
 
-class YustDocBuilder<T extends YustDoc> extends StatelessWidget {
+class YustDocBuilder<T extends YustDoc> extends StatefulWidget {
   final YustDocSetup modelSetup;
   final String id;
   final List<List<dynamic>> filter;
   final List<String> orderBy;
-  final bool doNotWait;
-  final bool createIfNull;
+  final bool _doNotWait;
+  final bool _createIfNull;
   final Widget Function(T, YustBuilderInsights) builder;
 
   YustDocBuilder({
@@ -25,33 +26,86 @@ class YustDocBuilder<T extends YustDoc> extends StatelessWidget {
     this.id,
     this.filter,
     this.orderBy,
-    this.doNotWait = false,
-    this.createIfNull = false,
+    bool doNotWait,
+    bool createIfNul,
     @required this.builder,
-  }) : super(key: key);
+  })  : assert(modelSetup != null),
+        assert(builder != null),
+        _doNotWait = doNotWait ?? false,
+        _createIfNull = createIfNul ?? false,
+        super(key: key);
+
+  @override
+  YustDocBuilderState<T> createState() => YustDocBuilderState<T>();
+}
+
+class YustDocBuilderState<T extends YustDoc> extends State<YustDocBuilder<T>> {
+  /// May not be null.
+  Stream<T> _docStream;
+
+  void initStream() {
+    if (widget.id != null) {
+      _docStream = Yust.service.getDoc<T>(
+        widget.modelSetup,
+        widget.id,
+      );
+    } else {
+      _docStream = Yust.service.getFirstDoc<T>(
+        widget.modelSetup,
+        widget.filter,
+        orderByList: widget.orderBy,
+      );
+    }
+  }
+
+  bool updateStreamConditionally(YustDocBuilder oldWidget) {
+    bool updated = false;
+
+    if (widget.modelSetup != oldWidget.modelSetup ||
+        widget.id != oldWidget.id ||
+        !ListEquality(ListEquality()).equals(widget.filter, oldWidget.filter) ||
+        !ListEquality().equals(widget.orderBy, oldWidget.orderBy)) {
+      updated = true;
+      initStream();
+    }
+
+    return updated;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    initStream();
+  }
+
+  @override
+  void didUpdateWidget(YustDocBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    updateStreamConditionally(oldWidget);
+  }
 
   @override
   Widget build(BuildContext context) {
-    final docStream = (id != null)
-        ? Yust.service.getDoc<T>(modelSetup, id)
-        : Yust.service.getFirstDoc<T>(modelSetup, filter, orderByList: orderBy);
     return StreamBuilder<T>(
-      stream: docStream,
+      stream: _docStream,
       builder: (context, snapshot) {
         if (snapshot.hasError) {
           throw snapshot.error;
         }
-        if (snapshot.connectionState == ConnectionState.waiting && !doNotWait) {
+        if (snapshot.connectionState == ConnectionState.waiting &&
+            !widget._doNotWait) {
           return Center(child: CircularProgressIndicator());
         }
         var doc = snapshot.data;
-        if (doc == null && createIfNull) {
-          doc = Yust.service.initDoc<T>(modelSetup);
+        if (doc == null && widget._createIfNull) {
+          doc = Yust.service.initDoc<T>(widget.modelSetup);
         }
         final opts = YustBuilderInsights(
           waiting: snapshot.connectionState == ConnectionState.waiting,
         );
-        return builder(doc, opts);
+        return widget.builder(doc, opts);
       },
     );
   }

--- a/lib/widgets/yust_docs_builder.dart
+++ b/lib/widgets/yust_docs_builder.dart
@@ -1,3 +1,4 @@
+import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
 
 import '../models/yust_doc.dart';
@@ -5,11 +6,13 @@ import '../models/yust_doc_setup.dart';
 import '../yust.dart';
 import 'yust_doc_builder.dart';
 
-class YustDocsBuilder<T extends YustDoc> extends StatelessWidget {
+class YustDocsBuilder<T extends YustDoc> extends StatefulWidget {
   final YustDocSetup modelSetup;
   final List<List<dynamic>> filter;
   final List<String> orderBy;
-  final bool doNotWait;
+  final bool _doNotWait;
+
+  /// There will never be a null for the list given.
   final Widget Function(List<T>, YustBuilderInsights) builder;
 
   YustDocsBuilder({
@@ -17,25 +20,72 @@ class YustDocsBuilder<T extends YustDoc> extends StatelessWidget {
     @required this.modelSetup,
     this.filter,
     this.orderBy,
-    this.doNotWait = false,
+    bool doNotWait,
     @required this.builder,
-  }) : super(key: key);
+  })  : assert(modelSetup != null),
+        assert(builder != null),
+        _doNotWait = doNotWait ?? false,
+        super(key: key);
+
+  @override
+  YustDocsBuilderState<T> createState() => YustDocsBuilderState<T>();
+}
+
+class YustDocsBuilderState<T extends YustDoc>
+    extends State<YustDocsBuilder<T>> {
+  /// May not be null.
+  Stream<List<T>> _docStream;
+
+  void initStream() {
+    _docStream = Yust.service.getDocs<T>(
+      widget.modelSetup,
+      filterList: widget.filter,
+      orderByList: widget.orderBy,
+    );
+  }
+
+  bool updateStreamConditionally(YustDocsBuilder oldWidget) {
+    bool updated = false;
+
+    if (widget.modelSetup != oldWidget.modelSetup ||
+        !ListEquality(ListEquality()).equals(widget.filter, oldWidget.filter) ||
+        !ListEquality().equals(widget.orderBy, oldWidget.orderBy)) {
+      updated = true;
+      initStream();
+    }
+
+    return updated;
+  }
+
+  @override
+  void initState() {
+    super.initState();
+
+    initStream();
+  }
+
+  @override
+  void didUpdateWidget(YustDocsBuilder oldWidget) {
+    super.didUpdateWidget(oldWidget);
+
+    updateStreamConditionally(oldWidget);
+  }
 
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<List<T>>(
-      stream: Yust.service
-          .getDocs<T>(modelSetup, filterList: filter, orderByList: orderBy),
+      stream: _docStream,
       builder: (context, snapshot) {
         if (snapshot.hasError) {
           throw snapshot.error;
         }
         final opts = YustBuilderInsights(
-            waiting: snapshot.connectionState == ConnectionState.waiting);
-        if (opts.waiting && !doNotWait) {
+          waiting: snapshot.connectionState == ConnectionState.waiting,
+        );
+        if (opts.waiting && !widget._doNotWait) {
           return Center(child: CircularProgressIndicator());
         }
-        return builder(snapshot.data ?? [], opts);
+        return widget.builder(snapshot.data ?? [], opts);
       },
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -142,7 +142,7 @@ packages:
     source: hosted
     version: "3.2.1"
   collection:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: collection
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   intl: ^0.16.0
   shared_preferences: ^0.5.4+3
   progress_dialog: ^1.2.0
+  collection: ^1.14.11
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Converts the builders to StatefulWidgets keeping their state even when the parent widget is rebuilt. This reduces unnecessary rebuilding of nested widgets and them losing their state, simply because the parent widget had to update.