### PR TITLE
Add Suffix to Text- & NumberField

### DIFF
--- a/lib/widgets/yust_number_field.dart
+++ b/lib/widgets/yust_number_field.dart
@@ -16,19 +16,21 @@ class YustNumberField extends StatefulWidget {
   final bool enabled;
   final YustInputStyle style;
   final Widget prefixIcon;
+  final Widget suffixIcon;
 
-  YustNumberField({
-    Key key,
-    this.label,
-    this.value,
-    this.onChanged,
-    this.onEditingComplete,
-    this.onTab,
-    this.enabled = true,
-    this.readOnly = false,
-    this.style,
-    this.prefixIcon,
-  }) : super(key: key);
+  YustNumberField(
+      {Key key,
+      this.label,
+      this.value,
+      this.onChanged,
+      this.onEditingComplete,
+      this.onTab,
+      this.enabled = true,
+      this.readOnly = false,
+      this.style,
+      this.prefixIcon,
+      this.suffixIcon})
+      : super(key: key);
 
   @override
   _YustNumberFieldState createState() => _YustNumberFieldState();
@@ -70,6 +72,7 @@ class _YustNumberFieldState extends State<YustNumberField> {
             ? OutlineInputBorder()
             : null,
         prefixIcon: widget.prefixIcon,
+        suffixIcon: widget.suffixIcon,
       ),
       controller: _controller,
       focusNode: _focusNode,

--- a/lib/widgets/yust_text_field.dart
+++ b/lib/widgets/yust_text_field.dart
@@ -16,6 +16,7 @@ class YustTextField extends StatefulWidget {
   final bool obscureText;
   final YustInputStyle style;
   final Widget prefixIcon;
+  final Widget suffixIcon;
   final TextCapitalization textCapitalization;
 
   YustTextField({
@@ -31,6 +32,7 @@ class YustTextField extends StatefulWidget {
     this.obscureText = false,
     this.style,
     this.prefixIcon,
+    this.suffixIcon,
     this.textCapitalization = TextCapitalization.sentences,
   }) : super(key: key);
 
@@ -71,6 +73,7 @@ class _YustTextFieldState extends State<YustTextField> {
             ? OutlineInputBorder()
             : null,
         prefixIcon: widget.prefixIcon,
+        suffixIcon: widget.suffixIcon,
       ),
       maxLines: widget.obscureText ? 1 : null,
       minLines: widget.minLines,


### PR DESCRIPTION
This allows to pass an `suffixIcon` to the `YustNumberField` & `YustTextField`