### PR TITLE
Add mapToJson support for non-primitive datatypes

### DIFF
--- a/lib/models/yust_doc.dart
+++ b/lib/models/yust_doc.dart
@@ -70,7 +70,13 @@ abstract class YustDoc {
       } else if (value is List) {
         return MapEntry(key, List.from(value));
       } else {
-        return MapEntry(key, value);
+        try {
+          // If toJson is defined for the type, use it.
+          return MapEntry(key, (value as dynamic).toJson());
+        } on NoSuchMethodError {
+          // Else: Just return the value
+          return MapEntry(key, value);
+        }
       }
     });
   }


### PR DESCRIPTION
Currently it's not possible to convert a structure like `Map<String, CustomClass>` to JSON using only the `YustDoc.mapToJson`-method.

If tried the CustomClass is simply not converted to JSON; resulting in an error if one would try to save it in e.g. firestore.
