### PR TITLE
Choose between Integer and Decimal input in Yustnumberfield

### DIFF
--- a/lib/widgets/yust_number_field.dart
+++ b/lib/widgets/yust_number_field.dart
@@ -13,6 +13,7 @@ class YustNumberField extends StatefulWidget {
   final ChangeCallback onEditingComplete;
   final TabCallback onTab;
   final bool readOnly;
+  final bool isInteger;
   final bool enabled;
   final YustInputStyle style;
   final Widget prefixIcon;
@@ -27,6 +28,7 @@ class YustNumberField extends StatefulWidget {
       this.onTab,
       this.enabled = true,
       this.readOnly = false,
+      this.isInteger = false,
       this.style,
       this.prefixIcon,
       this.suffixIcon})

--- a/lib/widgets/yust_number_field.dart
+++ b/lib/widgets/yust_number_field.dart
@@ -46,9 +46,16 @@ class _YustNumberFieldState extends State<YustNumberField> {
   @override
   void initState() {
     super.initState();
+    var textEditingController;
+    if (widget.isInteger) {
+      textEditingController =
+          TextEditingController(text: widget.value?.toInt().toString());
+    } else {
+      textEditingController = TextEditingController(
+          text: widget.value?.toString()?.replaceAll(RegExp(r'\.'), ','));
+    }
 
-    _controller = TextEditingController(
-        text: widget.value?.toString()?.replaceAll(RegExp(r'\.'), ','));
+    _controller = textEditingController;
     _focusNode.addListener(() {
       if (!_focusNode.hasFocus && widget.onEditingComplete != null) {
         widget.onEditingComplete(_valueToNum(_controller.value.text.trim()));
@@ -91,9 +98,12 @@ class _YustNumberFieldState extends State<YustNumberField> {
             },
       keyboardType: kIsWeb
           ? null
-          : TextInputType.numberWithOptions(decimal: true, signed: true),
+          : TextInputType.numberWithOptions(
+              decimal: !widget.isInteger, signed: true),
       inputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp("[0-9\,\.\-]"))
+        widget.isInteger
+            ? FilteringTextInputFormatter.allow(RegExp("[0-9\-]"))
+            : FilteringTextInputFormatter.allow(RegExp("[0-9\,\.\-]"))
       ],
       textInputAction: TextInputAction.next,
       onTap: widget.onTab,

--- a/lib/widgets/yust_number_field.dart
+++ b/lib/widgets/yust_number_field.dart
@@ -46,16 +46,13 @@ class _YustNumberFieldState extends State<YustNumberField> {
   @override
   void initState() {
     super.initState();
-    var textEditingController;
     if (widget.isInteger) {
-      textEditingController =
+      _controller =
           TextEditingController(text: widget.value?.toInt().toString());
     } else {
-      textEditingController = TextEditingController(
+      _controller = TextEditingController(
           text: widget.value?.toString()?.replaceAll(RegExp(r'\.'), ','));
     }
-
-    _controller = textEditingController;
     _focusNode.addListener(() {
       if (!_focusNode.hasFocus && widget.onEditingComplete != null) {
         widget.onEditingComplete(_valueToNum(_controller.value.text.trim()));


### PR DESCRIPTION
This will add an attribute to the Yustnumberfield, which determines, whether the input should allow decimal numbers or not. The default is still 'accept decimal numbers' to support legacy code. If one wants to only allow integers, just set the isInteger attribute to true. This will prevent the input of decimal numbers in a field dedicated for integers.