### PR TITLE
Add the readOnly argument to more Widgets

### DIFF
--- a/lib/util/yust_serializable.dart
+++ b/lib/util/yust_serializable.dart
@@ -1,3 +1,3 @@
 abstract class YustSerializable {
-  Map<String, dynamic> toJson();
+  dynamic toJson();
 }

--- a/lib/widgets/yust_date_picker.dart
+++ b/lib/widgets/yust_date_picker.dart
@@ -12,6 +12,7 @@ class YustDatePicker extends StatelessWidget {
   final bool hideClearButton;
   final YustInputStyle style;
   final Widget prefixIcon;
+  final bool readOnly;
 
   YustDatePicker({
     Key key,
@@ -22,6 +23,7 @@ class YustDatePicker extends StatelessWidget {
     this.hideClearButton = false,
     this.style = YustInputStyle.normal,
     this.prefixIcon,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -68,7 +70,8 @@ class YustDatePicker extends StatelessWidget {
       return ListTile(
         title: Text(dateText),
         trailing: _buildClearDate(context),
-        onTap: onChanged == null ? null : () => _pickDate(context),
+        onTap:
+            (onChanged == null || readOnly) ? null : () => _pickDate(context),
         contentPadding: padding,
       );
     } else {
@@ -96,14 +99,15 @@ class YustDatePicker extends StatelessWidget {
             _buildClearDate(context),
           ],
         ),
-        onTap: onChanged == null ? null : () => _pickDate(context),
+        onTap:
+            (onChanged == null || readOnly) ? null : () => _pickDate(context),
         contentPadding: padding,
       );
     }
   }
 
   Widget _buildClearDate(BuildContext context) {
-    if (value == null || hideClearButton) {
+    if (value == null || hideClearButton || readOnly) {
       return SizedBox.shrink();
     }
     return IconButton(

--- a/lib/widgets/yust_file_picker.dart
+++ b/lib/widgets/yust_file_picker.dart
@@ -17,6 +17,7 @@ class YustFilePicker extends StatefulWidget {
   final List<Map<String, String>> files;
   final void Function(List<Map<String, String>> files) onChanged;
   final Widget prefixIcon;
+  final bool readOnly;
 
   YustFilePicker({
     Key key,
@@ -25,6 +26,7 @@ class YustFilePicker extends StatefulWidget {
     this.files,
     this.onChanged,
     this.prefixIcon,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -39,7 +41,7 @@ class _YustFilePickerState extends State<YustFilePicker> {
   @override
   void initState() {
     _files = widget.files;
-    _enabled = widget.onChanged != null;
+    _enabled = (widget.onChanged != null && !widget.readOnly);
     super.initState();
   }
 

--- a/lib/widgets/yust_image_picker.dart
+++ b/lib/widgets/yust_image_picker.dart
@@ -21,6 +21,7 @@ class YustImagePicker extends StatefulWidget {
   final bool zoomable;
   final void Function(List<Map<String, dynamic>> images) onChanged;
   final Widget prefixIcon;
+  final bool readOnly;
 
   YustImagePicker({
     Key key,
@@ -31,6 +32,7 @@ class YustImagePicker extends StatefulWidget {
     this.zoomable = false,
     this.onChanged,
     this.prefixIcon,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -52,7 +54,7 @@ class _YustImagePickerState extends State<YustImagePicker> {
           .map<YustFile>((image) => YustFile.fromJson(image))
           .toList();
     }
-    _enabled = widget.onChanged != null;
+    _enabled = (widget.onChanged != null && !widget.readOnly);
     super.initState();
   }
 
@@ -125,7 +127,7 @@ class _YustImagePickerState extends State<YustImagePicker> {
   }
 
   Widget _buildPickButtons(BuildContext context) {
-    if (!widget.multiple && _files?.firstOrNull != null) {
+    if (!_enabled || (!widget.multiple && _files?.firstOrNull != null)) {
       return SizedBox.shrink();
     }
     if (kIsWeb) {

--- a/lib/widgets/yust_select.dart
+++ b/lib/widgets/yust_select.dart
@@ -9,6 +9,7 @@ class YustSelect<T> extends StatelessWidget {
   final void Function(T) onSelected;
   final YustInputStyle style;
   final Widget prefixIcon;
+  final bool readOnly;
 
   const YustSelect({
     Key key,
@@ -19,6 +20,7 @@ class YustSelect<T> extends StatelessWidget {
     this.onSelected,
     this.style = YustInputStyle.normal,
     this.prefixIcon,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -56,7 +58,9 @@ class YustSelect<T> extends StatelessWidget {
     if (label == null) {
       return ListTile(
         title: Text(_valueCaption(value)),
-        onTap: onSelected == null ? null : () => _selectValue(context),
+        onTap: (onSelected == null || readOnly)
+            ? null
+            : () => _selectValue(context),
         contentPadding: padding,
       );
     } else {
@@ -82,7 +86,9 @@ class YustSelect<T> extends StatelessWidget {
               BoxConstraints(maxWidth: MediaQuery.of(context).size.width - 150),
           child: Text(_valueCaption(value)),
         ),
-        onTap: onSelected == null ? null : () => _selectValue(context),
+        onTap: (onSelected == null || readOnly)
+            ? null
+            : () => _selectValue(context),
         contentPadding: padding,
       );
     }

--- a/lib/widgets/yust_switch.dart
+++ b/lib/widgets/yust_switch.dart
@@ -7,6 +7,7 @@ class YustSwitch extends StatelessWidget {
   final Color activeColor;
   final Widget prefixIcon;
   final void Function(bool) onChanged;
+  final bool readOnly;
 
   const YustSwitch({
     Key key,
@@ -15,6 +16,7 @@ class YustSwitch extends StatelessWidget {
     this.activeColor,
     this.prefixIcon,
     this.onChanged,
+    this.readOnly = false,
   }) : super(key: key);
 
   @override
@@ -23,7 +25,7 @@ class YustSwitch extends StatelessWidget {
         child: Switch(
           value: value,
           activeColor: activeColor,
-          onChanged: onChanged,
+          onChanged: readOnly ? null : onChanged,
         ),
         label: label,
         prefixIcon: prefixIcon);


### PR DESCRIPTION
Add the `readOnly` boolean argument for `YustDatePicker`, `YustFilePicker`, `YustImagePicker`, `YustSelect` & `YustSwitch`.

For some Widgets a similar experience was archived  by setting `onChanged = null`, for downwards compatibility I haven't changed this behaviour on these Widgets.

The Change in `lib/util/yust_serializable.dart` is unrelated to the readOnly-Argument and needed to allow the serialisation from and to JSON-Arrays.