### PR TITLE
Feature: Initial text for showTextFieldDialog

### DIFF
--- a/lib/yust_service.dart
+++ b/lib/yust_service.dart
@@ -536,8 +536,13 @@ class YustService {
   }
 
   Future<String> showTextFieldDialog(
-      BuildContext context, String title, String placeholder, String action) {
-    final controller = TextEditingController();
+    BuildContext context,
+    String title,
+    String placeholder,
+    String action, [
+    String initialText = '',
+  ]) {
+    final controller = TextEditingController(text: initialText);
     return showDialog<String>(
         context: context,
         builder: (BuildContext context) {


### PR DESCRIPTION
Added a `initalText` Paramter to the `showTextFieldDialog` service method to set the initial text.