### PR TITLE
Fix: Remove unnecessary Null Checks

### DIFF
--- a/lib/widgets/yust_file_picker.dart
+++ b/lib/widgets/yust_file_picker.dart
@@ -154,7 +154,7 @@ class YustFilePickerState extends State<YustFilePicker> {
       final result = await FilePicker.platform.pickFiles(allowMultiple: true);
       if (result != null) {
         for (final platformFile in result.files) {
-          var name = platformFile.name!.split('/').last;
+          var name = platformFile.name.split('/').last;
           final ext = platformFile.extension;
           if (ext != null && name.split('.').last != ext) {
             name += '.' + ext;

--- a/lib/widgets/yust_image_picker.dart
+++ b/lib/widgets/yust_image_picker.dart
@@ -363,7 +363,7 @@ class YustImagePickerState extends State<YustImagePicker> {
           if (result != null) {
             for (final platformFile in result.files) {
               await uploadFile(
-                path: platformFile.name!,
+                path: platformFile.name,
                 bytes: platformFile.bytes,
                 resize: true,
                 yustQuality: widget.yustQuality,
@@ -375,7 +375,7 @@ class YustImagePickerState extends State<YustImagePicker> {
               await FilePicker.platform.pickFiles(type: FileType.image);
           if (result != null) {
             await uploadFile(
-                path: result.files.single.name!,
+                path: result.files.single.name,
                 bytes: result.files.single.bytes,
                 resize: true,
                 yustQuality: widget.yustQuality);


### PR DESCRIPTION
This thereby removes the following well-known logs:
```
..../yust_image_picker.dart:366:36: Warning: Operand of null-aware operation '!' has type 'String' which excludes null.
                path: platformFile.name!,
                                   ^
..../yust_image_picker.dart:378:43: Warning: Operand of null-aware operation '!' has type 'String' which excludes null.
                path: result.files.single.name!,

                                          ^
..../yust_file_picker.dart:157:35: Warning: Operand of null-aware operation '!' has type 'String' which excludes null.
          var name = platformFile.name!.split('/').last;
```