### PR TITLE
Fix: Use new Firestore Emulator API

### DIFF
--- a/lib/yust.dart
+++ b/lib/yust.dart
@@ -31,11 +31,7 @@ class Yust {
 
   /// Connnect to the firebase emulator for Firestore and Authentication
   static Future _connectToFirebaseEmulator(String address) async {
-    FirebaseFirestore.instance.settings = Settings(
-      host: '$address:8080',
-      sslEnabled: false,
-      persistenceEnabled: false,
-    );
+    FirebaseFirestore.instance.useFirestoreEmulator(address, 8080);
 
     await FirebaseAuth.instance.useEmulator('http://$address:9099');
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -140,21 +140,21 @@ packages:
       name: cloud_firestore
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.5.3"
   cloud_firestore_platform_interface:
     dependency: transitive
     description:
       name: cloud_firestore_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.1"
+    version: "5.4.2"
   cloud_firestore_web:
     dependency: transitive
     description:
       name: cloud_firestore_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.4.3"
   code_builder:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   json_annotation: ^4.0.1
   firebase_core: ^1.1.0
   firebase_auth: ^1.1.3
-  cloud_firestore: ^2.0.0
+  cloud_firestore: ^2.5.3
   firebase_storage: ^8.1.0
 
   provider: ^5.0.0


### PR DESCRIPTION
The PR #67 introduces a new firestore version. 
That Version (2.5.3) has a new Emulator-API, therefore the old way will not work.
This PR can be merged before or after #67 to keep the emulator working.