### PR TITLE
Support mocked Unit-Tests

### DIFF
--- a/lib/services/yust_auth_service.dart
+++ b/lib/services/yust_auth_service.dart
@@ -2,12 +2,15 @@ import 'dart:async';
 
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-
+import 'package:firebase_auth_mocks/firebase_auth_mocks.dart';
 import '../models/yust_user.dart';
 import '../yust.dart';
 
 class YustAuthService {
-  final FirebaseAuth fireAuth = FirebaseAuth.instance;
+  FirebaseAuth fireAuth;
+
+  YustAuthService() : fireAuth = FirebaseAuth.instance;
+  YustAuthService.mocked() : fireAuth = new MockFirebaseAuth();
 
   Future<void> signIn(
     BuildContext context,

--- a/lib/services/yust_database_service.dart
+++ b/lib/services/yust_database_service.dart
@@ -1,10 +1,16 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:yust/models/yust_doc.dart';
 import 'package:yust/models/yust_doc_setup.dart';
+import "package:fake_cloud_firestore/fake_cloud_firestore.dart";
 
 import '../yust.dart';
 
 class YustDatabaseService {
+  FirebaseFirestore fireStore;
+
+  YustDatabaseService() : fireStore = FirebaseFirestore.instance;
+  YustDatabaseService.mocked() : fireStore = new FakeFirebaseFirestore();
+
   /// Initialises a document with an id and the time it was created.
   ///
   /// Optionally an existing document can be given, which will still be
@@ -13,10 +19,7 @@ class YustDatabaseService {
     if (doc == null) {
       doc = modelSetup.newDoc();
     }
-    doc.id = FirebaseFirestore.instance
-        .collection(_getCollectionPath(modelSetup))
-        .doc()
-        .id;
+    doc.id = fireStore.collection(_getCollectionPath(modelSetup)).doc().id;
     doc.createdAt = DateTime.now();
     doc.createdBy = Yust.store.currUser?.id;
     if (modelSetup.forEnvironment) {
@@ -35,8 +38,7 @@ class YustDatabaseService {
       {required YustDocSetup<T> modelSetup,
       List<List<dynamic>>? filterList,
       List<String>? orderByList}) {
-    Query query =
-        FirebaseFirestore.instance.collection(_getCollectionPath(modelSetup));
+    Query query = fireStore.collection(_getCollectionPath(modelSetup));
     query = _executeStaticFilters(query, modelSetup);
     query = _executeFilterList(query, filterList);
     query = _executeOrderByList(query, orderByList);
@@ -106,7 +108,7 @@ class YustDatabaseService {
     YustDocSetup<T> modelSetup,
     String id,
   ) {
-    return FirebaseFirestore.instance
+    return fireStore
         .collection(_getCollectionPath(modelSetup))
         .doc(id)
         .snapshots()
@@ -117,7 +119,7 @@ class YustDatabaseService {
     YustDocSetup<T> modelSetup,
     String id,
   ) {
-    return FirebaseFirestore.instance
+    return fireStore
         .collection(_getCollectionPath(modelSetup))
         .doc(id)
         .get(GetOptions(source: Source.server))
@@ -174,8 +176,7 @@ class YustDatabaseService {
     bool trackModification = true,
     bool skipOnSave = false,
   }) async {
-    var collection =
-        FirebaseFirestore.instance.collection(_getCollectionPath(modelSetup));
+    var collection = fireStore.collection(_getCollectionPath(modelSetup));
     if (trackModification) {
       doc.modifiedAt = DateTime.now();
       doc.modifiedBy = Yust.store.currUser?.id;
@@ -216,9 +217,8 @@ class YustDatabaseService {
     if (modelSetup.onDelete != null) {
       await modelSetup.onDelete!(doc);
     }
-    var docRef = FirebaseFirestore.instance
-        .collection(_getCollectionPath(modelSetup))
-        .doc(doc.id);
+    var docRef =
+        fireStore.collection(_getCollectionPath(modelSetup)).doc(doc.id);
     await docRef.delete();
   }
 

--- a/lib/services/yust_file_service.dart
+++ b/lib/services/yust_file_service.dart
@@ -17,21 +17,25 @@ import 'package:path_provider/path_provider.dart';
 import 'package:share_plus/share_plus.dart';
 import 'package:yust/util/yust_exception.dart';
 import 'package:universal_html/html.dart' as html;
+import "package:firebase_storage_mocks/firebase_storage_mocks.dart";
 
 import '../yust.dart';
 
 class YustFileService {
+  firebase_storage.FirebaseStorage fireStorage;
+
+  YustFileService() : fireStorage = firebase_storage.FirebaseStorage.instance;
+
+  YustFileService.mocked() : fireStorage = new MockFirebaseStorage();
+
   Future<String> uploadFile(
       {required String path,
       required String name,
       File? file,
       Uint8List? bytes}) async {
     try {
-      final firebase_storage.Reference storageReference = firebase_storage
-          .FirebaseStorage.instance
-          .ref()
-          .child(path)
-          .child(name);
+      final firebase_storage.Reference storageReference =
+          fireStorage.ref().child(path).child(name);
       firebase_storage.UploadTask uploadTask;
       if (file != null) {
         uploadTask = storageReference.putFile(file);
@@ -51,7 +55,7 @@ class YustFileService {
   Future<Uint8List?> downloadFile(
       {required String path, required String name}) async {
     try {
-      return await firebase_storage.FirebaseStorage.instance
+      return await fireStorage
           .ref()
           .child(path)
           .child(name)
@@ -128,21 +132,13 @@ class YustFileService {
 
   Future<void> deleteFile({required String path, required String name}) async {
     try {
-      await firebase_storage.FirebaseStorage.instance
-          .ref()
-          .child(path)
-          .child(name)
-          .delete();
+      await fireStorage.ref().child(path).child(name).delete();
     } catch (e) {}
   }
 
   Future<bool> fileExist({required String path, required String name}) async {
     try {
-      await firebase_storage.FirebaseStorage.instance
-          .ref()
-          .child(path)
-          .child(name)
-          .getDownloadURL();
+      await fireStorage.ref().child(path).child(name).getDownloadURL();
     } on FirebaseException catch (_) {
       return false;
     }
@@ -151,11 +147,7 @@ class YustFileService {
 
   Future<String> getFileDownloadUrl(
       {required String path, required String name}) async {
-    return await firebase_storage.FirebaseStorage.instance
-        .ref()
-        .child(path)
-        .child(name)
-        .getDownloadURL();
+    return await fireStorage.ref().child(path).child(name).getDownloadURL();
   }
 
   Future<File> resizeImage({required File file, int maxWidth = 1024}) async {

--- a/lib/yust.dart
+++ b/lib/yust.dart
@@ -24,9 +24,9 @@ enum YustInputStyle {
 
 class Yust {
   static late YustStore store;
-  static final YustAuthService authService = YustAuthService();
-  static final YustDatabaseService databaseService = YustDatabaseService();
-  static final YustFileService fileService = YustFileService();
+  static late YustAuthService authService;
+  static late final YustDatabaseService databaseService;
+  static late final YustFileService fileService;
   static final YustAlertService alertService = YustAlertService();
   static final YustHelperService helperService = YustHelperService();
   static late YustDocSetup<YustUser> userSetup;
@@ -42,6 +42,13 @@ class Yust {
     await FirebaseAuth.instance.useEmulator('http://$address:9099');
 
     await FirebaseStorage.instance.useEmulator(host: address, port: 9199);
+  }
+
+  static Future<void> initializeMocked({YustStore? store}) async {
+    Yust.store = store ?? YustStore();
+    Yust.authService = YustAuthService.mocked();
+    Yust.databaseService = YustDatabaseService.mocked();
+    Yust.fileService = YustFileService.mocked();
   }
 
   static Future<void> initialize({
@@ -62,6 +69,9 @@ class Yust {
     }
 
     Yust.store = store ?? YustStore();
+    Yust.authService = YustAuthService();
+    Yust.databaseService = YustDatabaseService();
+    Yust.fileService = YustFileService();
     Yust.userSetup = userSetup as YustDocSetup<YustUser>? ?? YustUser.setup;
     Yust.useSubcollections = useSubcollections;
     Yust.envCollectionName = envCollectionName;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -267,6 +267,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   fake_async:
     dependency: transitive
     description:
@@ -274,6 +281,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  fake_cloud_firestore:
+    dependency: "direct dev"
+    description:
+      name: fake_cloud_firestore
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.3"
   ffi:
     dependency: transitive
     description:
@@ -301,21 +315,28 @@ packages:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.4"
+    version: "1.4.1"
+  firebase_auth_mocks:
+    dependency: "direct dev"
+    description:
+      name: firebase_auth_mocks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.2.2"
+    version: "4.3.1"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.3.1"
   firebase_core:
     dependency: "direct main"
     description:
@@ -344,6 +365,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.1.3"
+  firebase_storage_mocks:
+    dependency: "direct dev"
+    description:
+      name: firebase_storage_mocks
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.0"
   firebase_storage_platform_interface:
     dependency: transitive
     description:
@@ -562,6 +590,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  mockito:
+    dependency: transitive
+    description:
+      name: mockito
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.0.15"
   nested:
     dependency: transitive
     description:
@@ -744,6 +779,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.1+1"
+  rxdart:
+    dependency: transitive
+    description:
+      name: rxdart
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.27.3"
   share_plus:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 2.6.1
 homepage: https://github.com/janneskoehler/yust
 
 environment:
-  sdk: '>=2.12.0 <3.0.0'
+  sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
   flutter:
@@ -43,6 +43,9 @@ dev_dependencies:
     sdk: flutter
   build_runner: ^2.0.3
   json_serializable: ^4.1.0
+  fake_cloud_firestore: ^1.1.3
+  firebase_auth_mocks: ^0.7.1
+  firebase_storage_mocks: ^0.3.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://www.dartlang.org/tools/pub/pubspec


### PR DESCRIPTION
This is done by  allowing creation of a mocked yust instance.
E.g. 
```dart
Yust.initializeMocked();
```
instead of 
```dart
Yust.initialize();
```

Behind the scenes, the [FlutterFire UnitTest Packages](https://firebase.flutter.dev/docs/testing/testing/#unit-tests-using-fakes) are used.