### PR TITLE
fix YustPaginatedListView for Scrollbar

### DIFF
--- a/lib/widgets/yust_paginated_list_view.dart
+++ b/lib/widgets/yust_paginated_list_view.dart
@@ -45,6 +45,10 @@ class YustPaginatedListView<T extends YustDoc> extends StatelessWidget {
       query: query,
       itemsPerPage: 50,
       isLive: true,
+      initialLoader: SingleChildScrollView(
+        controller: scrollController,
+        child: CircularProgressIndicator(),
+      ),
     );
   }
 


### PR DESCRIPTION
Sets the initialLoader of the PaginateFirestore to a SingleChildScrollView which supports a Scrollbar.