### PR TITLE
Support NULL_Placeholder in `fromJSON` methods

### DIFF
--- a/lib/models/yust_doc.dart
+++ b/lib/models/yust_doc.dart
@@ -1,6 +1,9 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:json_annotation/json_annotation.dart';
+
 import 'package:yust/util/yust_serializable.dart';
+
+const NULL_PLACEHOLDER = 'NULL_VALUE';
 
 abstract class YustDoc with YustSerializable {
   @JsonKey()
@@ -40,12 +43,21 @@ abstract class YustDoc with YustSerializable {
 
   Map<String, dynamic> toJson();
 
+  static String? stringFromJson(String? str) {
+    if (str == NULL_PLACEHOLDER) {
+      return null;
+    }
+    return str;
+  }
+
   static Map<String, T?> mapFromJson<T>(Map<String, dynamic>? map) {
     if (map == null) {
       return {};
     }
     return map.map<String, T?>((key, value) {
-      if (value is FieldValue) {
+      if (value == NULL_PLACEHOLDER) {
+        return MapEntry(key, null);
+      } else if (value is FieldValue) {
         return MapEntry(key, null);
       } else if (value is Timestamp) {
         return MapEntry(key, YustDoc.convertTimestamp(value) as T?);

--- a/lib/models/yust_notification.g.dart
+++ b/lib/models/yust_notification.g.dart
@@ -6,22 +6,20 @@ part of 'yust_notification.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-YustNotification _$YustNotificationFromJson(Map json) {
-  return YustNotification(
-    forCollection: json['forCollection'] as String?,
-    forDocId: json['forDocId'] as String?,
-    title: json['title'] as String?,
-    body: json['body'] as String?,
-  )
-    ..id = json['id'] as String
-    ..createdAt = YustDoc.convertTimestamp(json['createdAt'])
-    ..createdBy = json['createdBy'] as String?
-    ..modifiedAt = YustDoc.convertTimestamp(json['modifiedAt'])
-    ..modifiedBy = json['modifiedBy'] as String?
-    ..userId = json['userId'] as String?
-    ..envId = json['envId'] as String?
-    ..data = Map<String, dynamic>.from(json['data'] as Map);
-}
+YustNotification _$YustNotificationFromJson(Map json) => YustNotification(
+      forCollection: json['forCollection'] as String?,
+      forDocId: json['forDocId'] as String?,
+      title: json['title'] as String?,
+      body: json['body'] as String?,
+    )
+      ..id = json['id'] as String
+      ..createdAt = YustDoc.convertTimestamp(json['createdAt'])
+      ..createdBy = json['createdBy'] as String?
+      ..modifiedAt = YustDoc.convertTimestamp(json['modifiedAt'])
+      ..modifiedBy = json['modifiedBy'] as String?
+      ..userId = json['userId'] as String?
+      ..envId = json['envId'] as String?
+      ..data = Map<String, dynamic>.from(json['data'] as Map);
 
 Map<String, dynamic> _$YustNotificationToJson(YustNotification instance) =>
     <String, dynamic>{

--- a/lib/models/yust_user.g.dart
+++ b/lib/models/yust_user.g.dart
@@ -6,25 +6,24 @@ part of 'yust_user.dart';
 // JsonSerializableGenerator
 // **************************************************************************
 
-YustUser _$YustUserFromJson(Map json) {
-  return YustUser(
-    email: json['email'] as String,
-    firstName: json['firstName'] as String,
-    lastName: json['lastName'] as String,
-    gender: _$enumDecodeNullable(_$YustGenderEnumMap, json['gender']),
-  )
-    ..id = json['id'] as String
-    ..createdAt = YustDoc.convertTimestamp(json['createdAt'])
-    ..createdBy = json['createdBy'] as String?
-    ..modifiedAt = YustDoc.convertTimestamp(json['modifiedAt'])
-    ..modifiedBy = json['modifiedBy'] as String?
-    ..userId = json['userId'] as String?
-    ..envId = json['envId'] as String?
-    ..envIds = Map<String, bool>.from(json['envIds'] as Map)
-    ..currEnvId = json['currEnvId'] as String?
-    ..deviceIds =
-        (json['deviceIds'] as List<dynamic>?)?.map((e) => e as String).toList();
-}
+YustUser _$YustUserFromJson(Map json) => YustUser(
+      email: json['email'] as String,
+      firstName: json['firstName'] as String,
+      lastName: json['lastName'] as String,
+      gender: $enumDecodeNullable(_$YustGenderEnumMap, json['gender']),
+    )
+      ..id = json['id'] as String
+      ..createdAt = YustDoc.convertTimestamp(json['createdAt'])
+      ..createdBy = json['createdBy'] as String?
+      ..modifiedAt = YustDoc.convertTimestamp(json['modifiedAt'])
+      ..modifiedBy = json['modifiedBy'] as String?
+      ..userId = json['userId'] as String?
+      ..envId = json['envId'] as String?
+      ..envIds = Map<String, bool?>.from(json['envIds'] as Map)
+      ..currEnvId = json['currEnvId'] as String?
+      ..deviceIds = (json['deviceIds'] as List<dynamic>?)
+          ?.map((e) => e as String)
+          .toList();
 
 Map<String, dynamic> _$YustUserToJson(YustUser instance) => <String, dynamic>{
       'id': instance.id,
@@ -42,43 +41,6 @@ Map<String, dynamic> _$YustUserToJson(YustUser instance) => <String, dynamic>{
       'currEnvId': instance.currEnvId,
       'deviceIds': instance.deviceIds,
     };
-
-K _$enumDecode<K, V>(
-  Map<K, V> enumValues,
-  Object? source, {
-  K? unknownValue,
-}) {
-  if (source == null) {
-    throw ArgumentError(
-      'A value must be provided. Supported values: '
-      '${enumValues.values.join(', ')}',
-    );
-  }
-
-  return enumValues.entries.singleWhere(
-    (e) => e.value == source,
-    orElse: () {
-      if (unknownValue == null) {
-        throw ArgumentError(
-          '`$source` is not one of the supported values: '
-          '${enumValues.values.join(', ')}',
-        );
-      }
-      return MapEntry(unknownValue, enumValues.values.first);
-    },
-  ).key;
-}
-
-K? _$enumDecodeNullable<K, V>(
-  Map<K, V> enumValues,
-  dynamic source, {
-  K? unknownValue,
-}) {
-  if (source == null) {
-    return null;
-  }
-  return _$enumDecode<K, V>(enumValues, source, unknownValue: unknownValue);
-}
 
 const _$YustGenderEnumMap = {
   YustGender.male: 'male',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "20.0.0"
+    version: "31.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "2.8.0"
   archive:
     dependency: transitive
     description:
@@ -56,7 +56,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.1"
   build_config:
     dependency: transitive
     description:
@@ -77,21 +77,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.6"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.7"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.0.0"
+    version: "7.2.3"
   built_collection:
     dependency: transitive
     description:
@@ -252,7 +252,7 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.1"
   dbus:
     dependency: transitive
     description:
@@ -547,14 +547,14 @@ packages:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.4.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.2"
+    version: "6.1.4"
   logging:
     dependency: transitive
     description:
@@ -673,7 +673,7 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   path_provider:
     dependency: "direct main"
     description:
@@ -902,14 +902,21 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.2.1"
+  source_helper:
+    dependency: transitive
+    description:
+      name: source_helper
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.3.1"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.1"
+    version: "1.8.2"
   stack_trace:
     dependency: transitive
     description:
@@ -951,7 +958,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.9"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  json_annotation: ^4.0.1
+  json_annotation: ^4.4.0
   firebase_core: ^1.1.0
   firebase_auth: ^1.1.3
   cloud_firestore: ^2.5.3
@@ -42,7 +42,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   build_runner: ^2.0.3
-  json_serializable: ^4.1.0
+  json_serializable: ^6.1.4
   fake_cloud_firestore: ^1.1.3
   firebase_auth_mocks: ^0.7.1
   firebase_storage_mocks: ^0.3.0


### PR DESCRIPTION
Automaticly converts the `NULL_PLACEHOLDER` (set as the string `'NULL_VALUE'` for now) to null in the existing `mapFromJson`-Method.

Also adds a `stringFromJson`-Method & updates the `json_serializable` dependency