### PR TITLE
Remove the need to provide a document in saveNewDoc

### DIFF
--- a/lib/services/yust_database_service.dart
+++ b/lib/services/yust_database_service.dart
@@ -237,7 +237,7 @@ class YustDatabaseService {
   /// An existing document can be given which will instead be initialised.
   Future<T> saveNewDoc<T extends YustDoc>(
     YustDocSetup<T> modelSetup, {
-    required T doc,
+    T? doc,
     Future<void> Function(T)? onInitialised,
   }) async {
     doc = initDoc<T>(modelSetup, doc);


### PR DESCRIPTION
Currently it is necessary to provide a newly created object to `saveNewDoc`, although it is perfectly capable of creating it itself. This change removes that necessity, thus easing its usage.