### PR TITLE
Convert timestamps to local timezone

### DIFF
--- a/lib/models/yust_doc.dart
+++ b/lib/models/yust_doc.dart
@@ -115,9 +115,11 @@ abstract class YustDoc with YustSerializable {
 
   static dynamic convertTimestamp(dynamic value) {
     if (value is Timestamp) {
-      return value.toDate();
+      return value.toDate().toLocal();
     } else if (value is Map && value['_seconds'] != null) {
-      return Timestamp(value['_seconds'], value['_nanoseconds']).toDate();
+      return Timestamp(value['_seconds'], value['_nanoseconds'])
+          .toDate()
+          .toLocal();
     } else {
       return value;
     }

--- a/lib/services/yust_helper_service.dart
+++ b/lib/services/yust_helper_service.dart
@@ -17,7 +17,7 @@ class YustHelperService {
     if (dateTime == null) return '';
 
     var formatter = DateFormat(format ?? 'dd.MM.yyyy');
-    return formatter.format(dateTime);
+    return formatter.format(dateTime.toLocal());
   }
 
   /// Does not return null.
@@ -25,7 +25,7 @@ class YustHelperService {
     if (dateTime == null) return '';
 
     var formatter = DateFormat(format ?? 'HH:mm');
-    return formatter.format(dateTime);
+    return formatter.format(dateTime.toLocal());
   }
 
   /// Creates a string formatted just as the [YustDoc.createdAt] property is.


### PR DESCRIPTION
This makes sure that parsing & formatting of timestamps are using local time.

E.g.:
```dart
.formatDate(DateTime.parse('2021-11-07T00:00:00.000')) -> 07.11.2021
.formatDate(DateTime.parse('2021-11-06T23:00:00.000Z')) ->  07.11.2021;
```
(While before the second command would have resulted in 06.11.2021)