### PR TITLE
Fix: Share-Dialog without Origin (iPad-only)

### DIFF
--- a/lib/services/yust_file_service.dart
+++ b/lib/services/yust_file_service.dart
@@ -91,11 +91,22 @@ class YustFileService {
         file.writeAsBytesSync(data);
       }
       if (file != null) {
+        final Size size = MediaQuery.of(context).size;
+        // Get the Location of the widget (e.g. button), that called the method.
         final box = context.findRenderObject() as RenderBox?;
+        final buttonLocation = box!.localToGlobal(Offset.zero) & box.size;
+
+        // Alternatively create a Location in the center of the Screen
+        final centerLocation = Rect.fromLTWH(0, 0, size.width, size.height / 2);
+
+        // If we don't have a useful button location, use the center position
+        final sharePositionOrigin = buttonLocation.height >= size.height
+            ? centerLocation
+            : buttonLocation;
         await Share.shareFiles(
           [file.path],
           subject: name,
-          sharePositionOrigin: box!.localToGlobal(Offset.zero) & box.size,
+          sharePositionOrigin: sharePositionOrigin,
         );
       }
     }


### PR DESCRIPTION
Usually when we call `Yust.fileService.launchFile(context: context, ...)` it get's called with the context of a button or similar, and therefore the Share-Dialog will pop-up next to the button (on iPads). 

But it might also get called without a useful origin for the Share-Dialog, then we need to position it in the middle of the screen. (Currently it's not visible in this case)