### PR TITLE
Fix Firebase-Auth Emulator URL

### DIFF
--- a/lib/yust.dart
+++ b/lib/yust.dart
@@ -41,7 +41,7 @@ class Yust {
   static Future<void> _connectToFirebaseEmulator(String address) async {
     FirebaseFirestore.instance.useFirestoreEmulator(address, 8080);
 
-    await FirebaseAuth.instance.useAuthEmulator('http://$address', 9099);
+    await FirebaseAuth.instance.useAuthEmulator(address, 9099);
 
     await FirebaseStorage.instance.useStorageEmulator(address, 9199);
   }


### PR DESCRIPTION
In an update to firebase auth the URL format for the emulator has changed. 
This PR aligns our `_connectToFirebaseEmulator` function.