### PR TITLE
Fix: Upload for multiple images

### DIFF
--- a/lib/widgets/yust_image_picker.dart
+++ b/lib/widgets/yust_image_picker.dart
@@ -343,9 +343,11 @@ class YustImagePickerState extends State<YustImagePicker> {
         path.split('.').last;
     final newFile =
         YustFile(name: imageName, file: file, bytes: bytes, processing: true);
-    setState(() {
-      _files.add(newFile);
-    });
+    _files.add(newFile);
+    if (mounted) {
+      setState(() {});
+    }
+
     try {
       if (resize) {
         final size = YustImageQuality[widget.yustQuality]!['size']!;


### PR DESCRIPTION
When uploading multiple files, the `uploadFile` method is called multiple times, which results in `widget.onChanged` being called before the last image has been uploaded, which in turn results in the ImagePicker being re-rendered, thus the state disposed and the next `setState` call results in an error.
Apart from a general refactoring of the logic, Flutter suggests to just check the `mounted`-Boolean, which this PR does.