### PR TITLE
Improve image picker resizing performance

### DIFF
--- a/lib/services/yust_file_service.dart
+++ b/lib/services/yust_file_service.dart
@@ -193,20 +193,24 @@ class YustFileService {
       required Uint8List bytes,
       int maxWidth = 1024}) async {
     if (kIsWeb) {
-      var imageOutput = await _resizeImageWeb(bytes, name, maxWidth);
-      return imageOutput;
+      return await _resizeImageWeb(bytes, name, maxWidth);
     } else {
-      var image = image_lib.decodeNamedImage(bytes, name)!;
-      if (image.width > image.height && image.width > maxWidth) {
-        image = Image.file(await FlutterNativeImage.compressImage(name,
-            targetWidth: maxWidth)) as image_lib.Image;
-      } else if (image.height > image.width && image.height > maxWidth) {
-        image = Image.file(await FlutterNativeImage.compressImage(name,
-            targetHeight: maxWidth)) as image_lib.Image;
-        image = image_lib.copyResize(image, height: maxWidth);
-      }
-      return image_lib.encodeNamedImage(image, name) as Uint8List?;
+      return await _resizeImageMobile(name, bytes, maxWidth);
     }
+  }
+
+  Future<Uint8List?> _resizeImageMobile(
+      String name, Uint8List bytes, int maxWidth) async {
+    var newImg = image_lib.decodeNamedImage(bytes, name)!;
+    if (newImg.width > newImg.height && newImg.width > maxWidth) {
+      newImg = Image.file(await FlutterNativeImage.compressImage(name,
+          targetWidth: maxWidth)) as image_lib.Image;
+    } else if (newImg.height > newImg.width && newImg.height > maxWidth) {
+      newImg = Image.file(await FlutterNativeImage.compressImage(name,
+          targetHeight: maxWidth)) as image_lib.Image;
+      newImg = image_lib.copyResize(newImg, height: maxWidth);
+    }
+    return image_lib.encodeNamedImage(newImg, name) as Uint8List?;
   }
 
   Future<Uint8List?> _resizeImageWeb(

--- a/lib/widgets/yust_image_picker.dart
+++ b/lib/widgets/yust_image_picker.dart
@@ -355,7 +355,7 @@ class YustImagePickerState extends State<YustImagePicker> {
           file = await Yust.fileService.resizeImage(file: file, maxWidth: size);
           newFile.file = file;
         } else {
-          bytes = Yust.fileService
+          bytes = await Yust.fileService
               .resizeImageBytes(name: path, bytes: bytes!, maxWidth: size);
           newFile.bytes = bytes;
         }


### PR DESCRIPTION
Reduces the duration for waiting to get a image preview in the YustImagePicker by changing the resizing functions in the YustFileService.
Web and Mobile are split due to [flutter_native_image](https://pub.dev/packages/flutter_native_image) available only for iOS and Android.
Web now uses a custom function and Mobile uses [flutter_native_image](https://pub.dev/packages/flutter_native_image) and [image](https://pub.dev/packages/image) for image resizing.

Work Items connected to this PR: 641 & 695.