### PR TITLE
Add file update in build function of YustFilePicker

### DIFF
--- a/lib/widgets/yust_file_picker.dart
+++ b/lib/widgets/yust_file_picker.dart
@@ -52,6 +52,7 @@ class YustFilePickerState extends State<YustFilePicker> {
 
   @override
   Widget build(BuildContext context) {
+    _files = widget.files;
     return YustListTile(
         suffixChild: _buildAddButton(context),
         label: widget.label,


### PR DESCRIPTION
Adds a refresh for the files in the build-method.
If the YustFilePicker gets rebuilt with new files they will be built.
Linked work item: 698 
Linked PR: [!573](https://dev.azure.com/univelop/Univelop/_git/Univelop/pullrequest/573)