### PR TITLE
Add drag and drop functions to filepicker

### DIFF
--- a/lib/widgets/yust_file_picker.dart
+++ b/lib/widgets/yust_file_picker.dart
@@ -102,21 +102,12 @@ class YustFilePickerState extends State<YustFilePicker> {
           child: _buildDropzoneArea(context),
         ),
         YustListTile(
-          suffixChild: _files.isEmpty ? null : _buildAddButton(context),
+          suffixChild:
+              isDragging ? _buildDropzoneInterface() : _buildAddButton(context),
           label: widget.label,
           prefixIcon: widget.prefixIcon,
-          below: _files.isEmpty
-              ? _buildDropzoneInterface(showManualUploadButton: true)
-              : _buildFiles(context),
+          below: _buildFiles(context),
         ),
-        _files.isNotEmpty && isDragging
-            ? Positioned.fill(
-                child: Container(
-                  color: Color.fromARGB(91, 118, 118, 118),
-                  child: _buildDropzoneInterface(showManualUploadButton: false),
-                ),
-              )
-            : Container()
       ],
     );
   }
@@ -154,12 +145,12 @@ class YustFilePickerState extends State<YustFilePicker> {
       );
 
   /// This Widget is a visual drag and drop indicator. It shows a dotted box, an icon as well as a button to manually upload files
-  Widget _buildDropzoneInterface({bool showManualUploadButton = true}) {
+  Widget _buildDropzoneInterface() {
     final dropZoneColor =
         isDragging ? Colors.blue : Color.fromARGB(255, 116, 116, 116);
     return Center(
       child: Padding(
-        padding: EdgeInsets.all(10),
+        padding: EdgeInsets.fromLTRB(100, 2, 2, 2),
         child: DottedBorder(
           borderType: BorderType.RRect,
           radius: Radius.circular(12),
@@ -173,24 +164,15 @@ class YustFilePickerState extends State<YustFilePicker> {
             child: Container(
               height: 200,
               width: 400,
-              child: Column(
+              child: Row(
                 mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                 children: [
                   Icon(Icons.cloud_upload_outlined,
-                      size: 40, color: dropZoneColor),
+                      size: 35, color: dropZoneColor),
                   Text(
                     'Datei(en) hierher ziehen',
                     style: TextStyle(fontSize: 20, color: dropZoneColor),
                   ),
-                  if (showManualUploadButton) ...[
-                    Text(
-                      'oder',
-                      style: TextStyle(color: dropZoneColor),
-                    ),
-                    OutlinedButton(
-                        child: Text("Dateien durchsuchen"),
-                        onPressed: _pickFiles),
-                  ]
                 ],
               ),
             ),

--- a/lib/widgets/yust_file_picker.dart
+++ b/lib/widgets/yust_file_picker.dart
@@ -58,20 +58,30 @@ class YustFilePickerState extends State<YustFilePicker> {
   }
 
   /// TODO:
-  ///    - show dropzone when dragging (without chose file)
-  ///    - indicate correct drop-location by changing color of dropzone
   ///    -
   @override
   Widget build(BuildContext context) {
     final showDropzone = kIsWeb && widget.enableDropzone && _files.isEmpty;
     return Stack(
       children: [
+        Positioned.fill(
+          child: _buildDropzoneArea(context),
+        ),
         YustListTile(
           suffixChild: showDropzone ? null : _buildAddButton(context),
           label: widget.label,
           prefixIcon: widget.prefixIcon,
           below: showDropzone ? _buildDropzone() : _buildFiles(context),
-        )
+        ),
+        isDragging
+            ? Positioned.fill(
+                child: Container(
+                  color: Color.fromARGB(
+                      91, 118, 118, 118), //TODO: change Color to defaults
+                  child: _buildDropzoneInterface(),
+                ),
+              )
+            : Container()
       ],
     );
   }
@@ -154,35 +164,43 @@ class YustFilePickerState extends State<YustFilePicker> {
 
   /// This Widget presents the dropzone with the icon
   Widget _buildDropzoneInterface() {
+    final dropZoneColor = isDragging
+        ? Colors.blue
+        : Color.fromARGB(255, 116, 116, 116); //TODO: use accent colors
     return Center(
-      child: DottedBorder(
-        borderType: BorderType.RRect,
-        radius: Radius.circular(12),
-        padding: EdgeInsets.all(6),
-        dashPattern: [6, 5],
-        strokeWidth: 3,
-        strokeCap: StrokeCap.round,
-        color: Color.fromARGB(255, 116, 116, 116),
-        child: ClipRRect(
-          borderRadius: BorderRadius.all(Radius.circular(12)),
-          child: Container(
-            height: 300,
-            width: 400,
-            child: Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Icon(
-                  Icons.cloud_upload_outlined,
-                  size: 40,
-                ),
-                Text(
-                  'Datei(en) hierher ziehen',
-                  style: TextStyle(fontSize: 20),
-                ),
-                Text('oder'),
-                OutlinedButton(
-                    child: Text("Dateien durchsuchen"), onPressed: _pickFiles),
-              ],
+      child: Padding(
+        padding: EdgeInsets.all(10),
+        child: DottedBorder(
+          borderType: BorderType.RRect,
+          radius: Radius.circular(12),
+          padding: EdgeInsets.all(6),
+          dashPattern: [6, 5],
+          strokeWidth: 3,
+          strokeCap: StrokeCap.round,
+          color: dropZoneColor,
+          child: ClipRRect(
+            borderRadius: BorderRadius.all(Radius.circular(12)),
+            child: Container(
+              height: 300,
+              width: 400,
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Icon(Icons.cloud_upload_outlined,
+                      size: 40, color: dropZoneColor),
+                  Text(
+                    'Datei(en) hierher ziehen',
+                    style: TextStyle(fontSize: 20, color: dropZoneColor),
+                  ),
+                  Text(
+                    'oder',
+                    style: TextStyle(color: dropZoneColor),
+                  ),
+                  OutlinedButton(
+                      child: Text("Dateien durchsuchen"),
+                      onPressed: _pickFiles),
+                ],
+              ),
             ),
           ),
         ),
@@ -199,11 +217,13 @@ class YustFilePickerState extends State<YustFilePicker> {
           onLoaded: () => null,
           onError: (ev) => null,
           onHover: () {
+            print("hover");
             setState(() {
               isDragging = true;
             });
           },
           onLeave: () {
+            print("leave");
             setState(() {
               isDragging = false;
             });

--- a/lib/widgets/yust_file_picker.dart
+++ b/lib/widgets/yust_file_picker.dart
@@ -144,15 +144,9 @@ class YustFilePickerState extends State<YustFilePicker> {
             setState(() {
               isDragging = false;
             });
-            print('Dropzone drop multiple: $ev');
             for (final file in ev ?? []) {
               final bytes = await controller.getFileData(file);
               await uploadFile(name: file.name, file: null, bytes: bytes);
-              if (bytes.length <= 20) {
-                print(bytes);
-              } else {
-                print(bytes.sublist(0, 20));
-              }
             }
             ;
           },

--- a/lib/widgets/yust_file_picker.dart
+++ b/lib/widgets/yust_file_picker.dart
@@ -105,8 +105,9 @@ class YustFilePickerState extends State<YustFilePicker> {
           suffixChild: _files.isEmpty ? null : _buildAddButton(context),
           label: widget.label,
           prefixIcon: widget.prefixIcon,
-          below:
-              _files.isEmpty ? _buildDropzoneInterface() : _buildFiles(context),
+          below: _files.isEmpty
+              ? _buildDropzoneInterface(showManualUploadButton: true)
+              : _buildFiles(context),
         ),
         _files.isNotEmpty && isDragging
             ? Positioned.fill(
@@ -146,7 +147,7 @@ class YustFilePickerState extends State<YustFilePicker> {
             print('Dropzone drop multiple: $ev');
             for (final file in ev ?? []) {
               final bytes = await controller.getFileData(file);
-              await _fileHandler.addFile(YustFile(name: file.name));
+              await uploadFile(name: file.name, file: null, bytes: bytes);
               if (bytes.length <= 20) {
                 print(bytes);
               } else {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,8 @@ dependencies:
   firebase_storage_mocks: ^0.5.0
   fake_cloud_firestore: ^1.1.3
   firebase_auth_mocks: ^0.8.2
+  flutter_dropzone: ^3.0.5
+  dotted_border: ^2.0.0+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR adds a Dropzone to the YustFilePicker, if the `enableDropzone` parameter is true. By default `enableDropzone` is false, so every existing software using the YustFilePicker does not change in any way.
If `enableDropzone` is set to `true` _AND_ the app is viewed in the web, a drop zone will appear. It is also possible to drag and drop new files onto already existing ones.

Tested on:
 - MacOS
    - from
       - Finder
       - Mail
    - to
       - Chrome
       - FireFox
 - Windows
    - from
       - Windows Explorer
    - to
       - Chrome