### PR TITLE
add global BroadcastStream

### DIFF
--- a/lib/services/yust_helper_service.dart
+++ b/lib/services/yust_helper_service.dart
@@ -1,9 +1,15 @@
 import 'dart:math';
 
+import 'package:connectivity_plus/connectivity_plus.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class YustHelperService {
+  /// Under Firefox only one BroadcastStream can be used for the
+  /// connectivity result. Therefore, use this stream instance
+  static final connectivityStream =
+      Connectivity().onConnectivityChanged.asBroadcastStream();
+
   /// Does unfocus the current focus node.
   void unfocusCurrent(BuildContext context) {
     final currentFocus = FocusScope.of(context);

--- a/lib/widgets/yust_image_picker.dart
+++ b/lib/widgets/yust_image_picker.dart
@@ -8,6 +8,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:yust/models/yust_file.dart';
+import 'package:yust/services/yust_helper_service.dart';
 import 'package:yust/util/yust_file_handler.dart';
 import 'package:yust/screens/yust_image_screen.dart';
 import 'package:yust/widgets/yust_list_tile.dart';
@@ -94,7 +95,7 @@ class YustImagePickerState extends State<YustImagePicker> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<ConnectivityResult>(
-      stream: Connectivity().onConnectivityChanged,
+      stream: YustHelperService.connectivityStream,
       builder: (context, snapshot) {
         if (snapshot.data != null) {
           _connectivityResult = snapshot.data!;


### PR DESCRIPTION
firefox does not support multiple BroadcastStreams for the connectivity result. Therefor we use one instance