### PR TITLE
Fix: Samsung Smart-Suggestions not working in TimeSpan-Picker

### DIFF
--- a/lib/widgets/yust_time_picker.dart
+++ b/lib/widgets/yust_time_picker.dart
@@ -72,7 +72,7 @@ class _YustTimePickerState extends State<YustTimePicker> {
     return Row(
       children: [
         Expanded(
-          child: TextField(
+          child: TextFormField(
             decoration: InputDecoration(
               labelText: widget.label,
               contentPadding: const EdgeInsets.all(20.0),


### PR DESCRIPTION
While I was not able to reproduce the error myself, [this issue/comment](https://d51.tech/uuNC) suggests that changing the `TextField` to a `TextFormField` might fix the issue.